### PR TITLE
Add travel, eCommerce, and social sites to the mix

### DIFF
--- a/sites.json
+++ b/sites.json
@@ -31,6 +31,120 @@
             ]
         },
         {
+           "name": "Social Media",
+           "linkname": "socialmedia",
+           "sites": [
+              {
+                "name": "LinkedIn",
+                "domain": "www.linkedin.com"
+              },
+              {
+                "name": "Facebook",
+                "domain": "www.facebook.com"
+              },
+              {
+                "name": "Twitter",
+                "domain": "www.twitter.com"
+              },
+              {
+                "name": "Pintrest",
+                "domain": "www.pinterest.com"
+              },
+              {
+                "name": "Tumblr",
+                "domain": "www.tumblr.com"
+              },
+              {
+                "name": "Instagram",
+                "domain": "www.instagram.com"
+              },
+              {
+                "name": "Vine",
+                "domain": "www.vine.com"
+              },
+              {
+                "name": "Vimeo",
+                "domain": "www.vimeo.com"
+              },
+              {
+                "name": "Match.com",
+                "domain": "www.match.com"
+              },
+              {
+                "name": "OkCupid",
+                "domain": "www.okcupid.com"
+              }
+           ]
+        },
+        {
+            "name": "E-Commerce Sites",
+            "linkname": "commerce",
+            "sites": [
+                {
+                  "name": "Apple",
+                  "domain": "store.apple.com"
+                },
+                {
+                    "name": "Amazon",
+                    "domain": "amazon.com"
+                },
+                {
+                    "name": "Ebay",
+                    "domain": "www.ebay.com"
+                },
+                {
+                    "name": "Target",
+                    "domain": "www.target.com"
+                },
+                {
+                    "name": "Walmart",
+                    "domain": "www.walmart.com"
+                },
+                {
+                    "name": "CVS",
+                    "domain": "www.cvs.com"
+                },
+                {
+                    "name": "Home Depot",
+                    "domain": "www.homedepot.com"
+                },
+                {
+                   "name": "Barnes & Noble",
+                   "domain": "www.barnesandnoble.com"
+                }
+            ]
+        },
+        {
+           "name": "Travel",
+           "linkname": "travel",
+           "sites": [
+              {
+                "name": "Southwest",
+                "domain": "www.southwest.com"
+              },
+              {
+                "name": "Delta",
+                "domain": "www.delta.com"
+              },
+              {
+                "name": "American Airlines",
+                "domain": "www.aa.com"
+              },
+              {
+                "name": "Kayak",
+                "domain": "www.kayak.com"
+              },
+              {
+                "name": "Travelocity",
+                "domain": "www.travelocity.com"
+              },
+              {
+                "name": "Expedia",
+                "domain": "www.expedia.com"
+              }
+           ]
+        },
+        {
             "name": "Newspapers",
             "linkname": "newspapers",
             "sites": [


### PR DESCRIPTION
I really like this idea of giving all of the major sites score cards on TLS.  It may be nice to add customized notes to each site about what could potentially be leaked or what is given up.

Here is a related Tumblr.  http://httpshaming.tumblr.com/

Here is a SS of some of the sites I added:

![screen shot 2015-01-18 at 8 45 16 pm](https://cloud.githubusercontent.com/assets/772364/5794996/02cbd8c6-9f53-11e4-8ac2-c44fc0a004af.png)