### PR TITLE
add Dart to sites.json

### DIFF
--- a/sites.json
+++ b/sites.json
@@ -395,6 +395,10 @@
                     "domain": "dlang.org"
                 },
                 {
+                    "name": "Dart",
+                    "domain": "www.dartlang.org"
+                },
+                {
                     "name": "Erlang",
                     "domain": "www.erlang.org"
                 },


### PR DESCRIPTION
While I absolutely agree that it is worthwhile to have a certain limit on how many sites are listed
imho it makes sense to pro-actively list a few sites that lead by example (same for universities and other categories).

Going forward it could be an interesting option to mark certain entries in the data set as 'featured' and hide/de-emphasize others behind a search field or a 'list all' action.