### PR TITLE
Adds POLITICO

### DIFF
--- a/sites.json
+++ b/sites.json
@@ -37,6 +37,10 @@
                     "domain": "www.nytimes.com"
                 },
                 {
+                    "name": "POLITICO",
+                    "domain": "www.politico.com"
+                },
+                {
                     "name": "Der Spiegel",
                     "domain": "www.spiegel.de"
                 },


### PR DESCRIPTION
For your consideration: this adds [POLITICO](http://www.politico.com/). While POLITICO isn't widely read on the mainstream national scene, it is tremendously huge inside and around Washington, DC. I'd love to have an excuse to write them and ask why they're not leading on this.