### PR TITLE
include shebang header

### DIFF
--- a/check_https.py
+++ b/check_https.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import argparse
 import collections
 import concurrent.futures


### PR DESCRIPTION
This is particularly handy for those of us with 2 and 3 installs. Should even work on Windows.